### PR TITLE
Add test for rpath patcher and symlinks into lib

### DIFF
--- a/tests/test-recipes/metadata/_rpath_symlink_reverse/meta.yaml
+++ b/tests/test-recipes/metadata/_rpath_symlink_reverse/meta.yaml
@@ -22,6 +22,8 @@ build:
     - ln -s "${PREFIX}/lib/subfolder/{{ lib_file }}" "${PREFIX}/lib/libthing.1.dylib"  # [osx]
     - ln -s "${PREFIX}/lib/subfolder/{{ lib_file }}" "${PREFIX}/lib/libthing.so"  # [linux]
     - ln -s "${PREFIX}/lib/subfolder/{{ lib_file }}" "${PREFIX}/lib/libthing.dylib"  # [osx]
+    - ln -s "${PREFIX}/lib/subfolder/{{ lib_file }}" "${PREFIX}/lib/{{ lib_file }}"  # [linux]
+    - ln -s "${PREFIX}/lib/subfolder/{{ lib_file }}" "${PREFIX}/lib/{{ lib_file }}"  # [osx]
 
 requirements:
   build:
@@ -36,6 +38,8 @@ test:
       python -c '
       import os, lief
       lib = lief.parse(os.environ["PREFIX"] + "/lib/{{ lib_file }}")
-      assert {"$ORIGIN/."} == {e.rpath for e in lib.dynamic_entries if e.tag == lief.ELF.DYNAMIC_TAGS.RPATH}  # [linux]
-      assert {"@loader_path/"} == {command.path for command in lib.commands if command.command == lief.MachO.LOAD_COMMAND_TYPES.RPATH}  # [osx]
+      dynamic_entries = {str(entry) for entry in lib.dynamic_entries}  # [linux]
+      assert {"$ORIGIN/."} == {e.rpath for e in lib.dynamic_entries if e.tag == lief.ELF.DYNAMIC_TAGS.RPATH}, "$ORIGIN rpath not found in: " + str(dynamic_entries)  # [linux]
+      commands = {str(command) for command in lib.commands}  # [osx]
+      assert {"@loader_path/"} == {command.path for command in lib.commands if command.command == lief.MachO.LOAD_COMMAND_TYPES.RPATH}, "loader path not found in: " + str(commands)  # [osx]
       '


### PR DESCRIPTION
The main problem was that you were trying to load the library at a filename that you never created. I'm not sure if you want to fix that the way that I have here, or instead change the filename being loaded in the test.

I was testing on a mac. Here's what I saw when I printed the commands output:

```
AssertionError: loader path not found in: {'Command : DATA_IN_CODE\nOffset  : 238\nSize    : 10\n\nData location:\nOffset  : 0x4008\nSize    : 0x0\n', 'Command : SEGMENT_64\nOffset  : b8\nSize    : 48\n__LINKEDIT     4000           4000           4000           5a0            1              1              0              0              \nSections in this segment :\n', 'Command : RPATH\nOffset  : 258\nSize    : 20\nPath:     @loader_path/../', 'Command : RPATH\nOffset  : 210\nSize    : 18\nPath:     $ORIGIN/.', 'Command : DYSYMTAB\nOffset  : 178\nSize    : 50\nFirst local symbol index:           0\nNumber of local symbols:            0\nExternal symbol index:              0\nNumber of external symbols:         0\nUndefined symbol index:             0\nNumber of undefined symbols:        0\nTable of content offset:            0\nNumber of entries in TOC:           0\nModule table offset:                0\nNumber of entries in module table:  0\nExternal reference table offset:    0\nNumber of external reference:       0\nIndirect symbols offset:            0\nNumber of indirect symbols:         0\nExternal relocation offset:         0\nNumber of external relocations:     0\nLocal relocation offset:            0\nNumber of local relocations:        0\n', 'Command : UUID\nOffset  : 1c8\nSize    : 18\n1b 61 5c fa ff 8e 3b 02 8e 0b ec 25 40 cb e3 f0 ', 'Command : BUILD_VERSION\nOffset  : 1e0\nSize    : 20\nPlatform: MACOS\n  Min OS: 11.0.0\n     SDK: 14.2.0\n  LD - 609.0.0\n\n', 'Command : SYMTAB\nOffset  : 160\nSize    : 18\n', 'Command : ID_DYLIB\nOffset  : 100\nSize    : 30\n@rpath/libthing.1.dylib            1 - 0.0.0 - 0.0.0', 'Command : SEGMENT_64\nOffset  : 20\nSize    : 98\n__TEXT         0              4000           0              4000           5              5              1              0              \nSections in this segment :\n\t__text           __TEXT           4000      0         4000      0         REGULAR                       0                   0                   0         0         0         SOME_INSTRUCTIONS PURE_INSTRUCTIONS\n', 'Command : SOURCE_VERSION\nOffset  : 200\nSize    : 10\nVersion: 0.0.0.0.0\n', 'Command : FUNCTION_STARTS\nOffset  : 228\nSize    : 10\n\nFunction starts location:\nOffset  : 0x4000\nSize    : 0x8\nFunctions (0):\n', 'Command : CODE_SIGNATURE\nOffset  : 248\nSize    : 10\n\nCode Signature location:\nOffset  : 0x4010\nSize    : 0x590\n', 'Command : DYLD_INFO_ONLY\nOffset  : 130\nSize    : 30\nType       Offset    Size\nRebase:    0         0\nBind:      0         0\nWeak bind: 0         0\nLazy bind: 0         0\nExport:    0         0\n'}
```

You'll be more familiar with this than me, but I see two entries that may be of interest:

```
 'Command : RPATH\nOffset  : 258\nSize    : 20\nPath:     @loader_path/../', 
'Command : RPATH\nOffset  : 210\nSize    : 18\nPath:     $ORIGIN/.',
```

I hope this helps.